### PR TITLE
Notebooks improvements

### DIFF
--- a/notebooks/investigate.ipynb
+++ b/notebooks/investigate.ipynb
@@ -20,6 +20,56 @@
    ]
   },
   {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "base_folder = \"/Users/georgwallmann/Documents/data/alphadia-validate/\"\n",
+    "data_folder = f'{base_folder}/data'\n",
+    "output_folder = f'{base_folder}/output'"
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "#### Obtain raw & results data\n",
+    "Note: this is just required if you did not run the search yourself in search_1.10.0.ipynb"
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "for folder in [data_folder, output_folder]:\n",
+    "    if not os.path.exists(folder):\n",
+    "        os.makedirs(folder)\n",
+    "\n",
+    "# HeLa library as used in the getting started guide\n",
+    "library_url = \"https://datashare.biochem.mpg.de/s/Uw2yfNSbApfPpTk\"\n",
+    "\n",
+    "# Bulk injections of HeLa cell lysate acquired on the Orbitrap Astral\n",
+    "raw_data_url_list = [\n",
+    "    \"https://datashare.biochem.mpg.de/s/339jg5HtGrwLwDN/download?files=20231017_OA2_TiHe_ADIAMA_HeLa_200ng_Evo011_21min_F-40_05.raw\",\n",
+    "    #\"https://datashare.biochem.mpg.de/s/339jg5HtGrwLwDN/download?files=20231017_OA2_TiHe_ADIAMA_HeLa_200ng_Evo011_21min_F-40_06.raw\",\n",
+    "    #\"https://datashare.biochem.mpg.de/s/339jg5HtGrwLwDN/download?files=20231017_OA2_TiHe_ADIAMA_HeLa_200ng_Evo011_21min_F-40_07.raw\",\n",
+    "]\n",
+    "\n",
+    "precursors_tsv_url = \"https://datashare.biochem.mpg.de/s/TODO/download?path=%2Fsecond_pass&files=precursors.tsv\"\n",
+    "speclib_url = \"https://datashare.biochem.mpg.de/s/TODO/download?path=%2Fsecond_pass&files=speclib.hdf\"\n",
+    "\n",
+    "\n",
+    "from alphadia.test_data_downloader import DataShareDownloader\n",
+    "_ = [DataShareDownloader(url, data_folder).download() for url in raw_data_url_list]\n",
+    "_ = DataShareDownloader(library_url, data_folder).download()\n",
+    "_ = DataShareDownloader(precursors_tsv_url, output_folder).download()\n",
+    "_ = DataShareDownloader(speclib_url, output_folder).download()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -39,13 +89,13 @@
    "outputs": [],
    "source": [
     "raw_files = [\n",
-    "     \"/Users/georgwallmann/Documents/data/alphadia-validate/data/20231017_OA2_TiHe_ADIAMA_HeLa_200ng_Evo011_21min_F-40_05.raw\"\n",
+    "     f\"{data_folder}/20231017_OA2_TiHe_ADIAMA_HeLa_200ng_Evo011_21min_F-40_05.raw\"\n",
     "]\n",
     "\n",
     "current_raw_name = os.path.basename(raw_files[0]).replace('.raw', '')\n",
     "current_raw_path = raw_files[0]\n",
     "\n",
-    "search_results = '/Users/georgwallmann/Documents/data/alphadia-validate/output'"
+    "search_results = output_folder"
    ]
   },
   {


### PR DESCRIPTION
- add a section on prerequisites
- make the second notebook self-contained
TODO: 
I don't know where to download the results data (precursors_tsv_url & speclib.hdf) from 